### PR TITLE
Rename python-scp to scp in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.26.4
 matplotlib==3.8.3
 scipy==1.12.0
 paramiko==3.4.0
-python-scp==0.14.5
+scp==0.14.5
 Pillow==10.3.0
 tkinterdnd2==0.3.0
 sv-ttk==2.6.0


### PR DESCRIPTION
## Fix dependency error

Replace `python-scp` with correct package name `scp` in requirements.txt.

The package `python-scp==0.14.5` doesn't exist on PyPI - the correct name is just `scp`.

Fixes installation error:
```
ERROR: No matching distribution found for python-scp==0.14.5
```